### PR TITLE
chore(ci): actions 升 Node 24 相容版 + 修 sync-upstream 幽靈失敗

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -35,10 +35,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,11 +1,9 @@
 name: 同步上游資料檔
 
+# 已停用自動排程（CLAUDE.md：不自動同步上游的上游），只保留手動觸發。
+# 注意：上游 templates.js 是雙語結構，0.8.0 起本 repo 已繁中特化（攤平為純字串），
+# 手動執行前先確認 sync-upstream.mjs 會處理攤平，否則會把資料檔打回雙語、弄壞站台。
 on:
-  # 每天 00:00 UTC 自動執行
-  schedule:
-    - cron: '0 0 * * *'
-
-  # 允許手動觸發
   workflow_dispatch:
 
 jobs:
@@ -70,19 +68,19 @@ jobs:
           git commit -m "chore: 同步 doggy8088/PromptFill 上游資料檔"
           git push origin "$BRANCH_NAME"
 
-          # 創建 PR
+          # 創建 PR（heredoc 內容必須縮排，貼齊 run 區塊，否則 YAML 解析失敗）
           gh pr create \
             --title "chore: 同步上游資料檔 $(date +%Y-%m-%d)" \
             --body "$(cat <<'EOF'
-## 自動同步上游資料檔
+          ## 自動同步上游資料檔
 
-此 PR 由 GitHub Actions 自動建立，同步來自 [doggy8088/PromptFill](https://github.com/doggy8088/PromptFill) 的資料檔：
+          此 PR 由 GitHub Actions 自動建立，同步來自 doggy8088/PromptFill 的資料檔：
 
-- `src/data/templates.js`
-- `src/data/banks.js`
+          - src/data/templates.js
+          - src/data/banks.js
 
-同步過程已自動執行詞彙修正（如：模板 → 範本）。
+          同步過程已自動執行詞彙修正（如：模板 → 範本）。
 
-請檢視變更後合併。
-EOF
-)"
+          請檢視變更後合併。
+          EOF
+          )"


### PR DESCRIPTION
## 改動

1. **deploy.yml**：GitHub 6/16 起 actions 強制跑 Node 24，升級 checkout@v6 / setup-node@v6 / configure-pages@v6 / upload-pages-artifact@v5 / deploy-pages@v5；build 用的 node 18（已 EOL）升 22（本機以 node 22 驗證過 build）。
2. **sync-upstream.yml**：找到每次 push 都出現 failed run 的根因 — heredoc 內容頂格寫在 YAML block scalar 外面，整個 workflow 檔解析失敗，GitHub 對每個 push 產生一個幽靈 failed run（run 名稱顯示檔案路徑就是這個症狀）。修正縮排，並按 repo CLAUDE.md「sync-upstream 已停用」的意圖移除 cron 排程、只留手動觸發 — 上游 templates.js 是雙語結構，自動同步會把 0.8.0 繁中特化的資料檔打回雙語重新弄壞站台。

## 驗證

- 兩個 workflow YAML 用 PyYAML 解析通過
- sync-upstream 內嵌 script 抽出後 `bash -n` 語法通過
- merge 後觀察：deploy 應綠、不再出現 sync-upstream 幽靈 failed run

🤖 Generated with [Claude Code](https://claude.com/claude-code)